### PR TITLE
Define ':stream' on 'writeToZipFile' method.

### DIFF
--- a/library/lib/nx-zip.tcl
+++ b/library/lib/nx-zip.tcl
@@ -68,6 +68,7 @@ namespace eval ::nx::zip {
     :public method writeToZipFile {zipFileName} {
       set fout [open $zipFileName w]
       fconfigure $fout -translation binary -encoding binary
+      set :writer [list puts -nonewline $fout]
       :writeToStream $fout
       close $fout
     }


### PR DESCRIPTION
After the nx::zip reform on 4f198095ea7d80ad414afda27850187f50716a49, methods called by 'writeToStream' use the command defined on ':writer' to create the zip file.

This was defined on 'ns_returnZipFile', but not on 'writeToZipFile', producing an 'can't read ":writer": no such variable' error when calling the latter.